### PR TITLE
Exclude paths from redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea
+.ruby-gemset
+.ruby-version

--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ and unzip it into `db/` in your project, **or** you could use the following
 It'd be a good idea to use this task on your (Capistrano or whatever) deployment
 scripts.
 
+### Excluding certain URLs from redirection
+
+You may want certain URLs in your app to be ignored by GeoRedirect and to 
+respond normally to *all* incoming requests. You can configure this with the 
+`:exclude` option. 
+
+    Rails.application.middleware.use GeoRedirect::Middleware, exclude: '/excluded_path'
+    
+The value of the option can be a string or an array of strings which represent 
+the path(s) to be excluded. Note that each string must be an exact match of the 
+path portion of the URL, including the leading slash.
+
+    Rails.application.middleware.use GeoRedirect::Middleware, exclude: '/exclude'
+    
+will match `www.myapp.com/exclude` but not `www.myapp.com/other/path/exclude`
+
 ### Custom paths
 
 The default paths for these files are:

--- a/lib/geo_redirect/middleware.rb
+++ b/lib/geo_redirect/middleware.rb
@@ -12,9 +12,10 @@ module GeoRedirect
 
       @app = app
 
-      @logger = init_logger(options[:logfile]) if options[:logfile]
-      @db     = init_db(options[:db])
-      @config = init_config(options[:config])
+      @logger   = init_logger(options[:logfile]) if options[:logfile]
+      @db       = init_db(options[:db])
+      @config   = init_config(options[:config])
+      @excludes = Array(options[:exclude])
 
       log 'Initialized middleware'
     end
@@ -60,7 +61,15 @@ module GeoRedirect
 
     def skip_redirect?
       url = URI.parse(@request.url)
+      query_includes_skip_geo?(url) or path_excluded?(url)
+    end
+
+    def query_includes_skip_geo?(url)
       Rack::Utils.parse_query(url.query).key? 'skip_geo'
+    end
+
+    def path_excluded?(url)
+      @excludes.reduce(false){ | result, exclude | result || url.path == exclude }
     end
 
     def handle_force

--- a/lib/geo_redirect/middleware.rb
+++ b/lib/geo_redirect/middleware.rb
@@ -69,7 +69,7 @@ module GeoRedirect
     end
 
     def path_excluded?(url)
-      @excludes.reduce(false){ | result, exclude | result || url.path == exclude }
+      @excludes.any?{ | exclude | url.path == exclude }
     end
 
     def handle_force

--- a/spec/geo_redirect_spec.rb
+++ b/spec/geo_redirect_spec.rb
@@ -237,7 +237,7 @@ describe 'geo_redirect' do
       end
 
       context 'when the request URL matches one of the excluded paths' do
-        before {mock_request_from 'US', path: '/exclude_me?query_param=value'}
+        before { mock_request_from 'US', path: '/exclude_me?query_param=value' }
 
         it { should_not_redirect }
         it { should_remember nil }
@@ -245,7 +245,7 @@ describe 'geo_redirect' do
       end
 
       context 'when the request URL does not match one of the excluded paths' do
-        before {mock_request_from 'US', path: '/dont_exclude_me?query_param=value'}
+        before { mock_request_from 'US', path: '/dont_exclude_me?query_param=value' }
 
         it { should_redirect_to :us }
         it { should_remember :us }
@@ -259,7 +259,7 @@ describe 'geo_redirect' do
       end
 
       context 'when the request URL matches one of the excluded paths' do
-        before {mock_request_from 'US', path: '/exclude_me?query_param=value'}
+        before { mock_request_from 'US', path: '/exclude_me?query_param=value' }
 
         it { should_not_redirect }
         it { should_remember nil }


### PR DESCRIPTION
My team has been using geo_redirect in our project for the last month, which has been working well.  However we need to exclude at least one URL from redirection in a similar way to that discussed in issue #19 

This pull request implements the `:exclude` option with the ability to pass one or more strings representing excluded paths.  Hopefully the addition to the README describes it clearly enough.